### PR TITLE
avoid exception in XFF code when no Headers

### DIFF
--- a/Kayak/Http/HttpServerTransactionDelegate.cs
+++ b/Kayak/Http/HttpServerTransactionDelegate.cs
@@ -125,7 +125,7 @@ namespace Kayak.Http
 
         void AddXFF(HttpRequestHead request, IPEndPoint remoteEndPoint)
         {
-            if (remoteEndPoint != null)
+            if (remoteEndPoint != null && request.Headers != null)
             {
                 if (request.Headers.ContainsKey("X-Forwarded-For"))
                 {


### PR DESCRIPTION
If a request has no headers at all, the XFF code throws an exception
