### PR TITLE
Multiple fixes for Rakefile.rb to work under Mac OS X/Linux/Mono

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -118,6 +118,10 @@ end
 def ensure_nuget_packages_nix(name, version) 
   # NuGet doesn't work on Mono. So we're going to manually download our dependencies from NuGet.org.
 
+  if !Dir.exist? PACKAGES_DIR then
+    FileUtils.mkdir_p PACKAGES_DIR
+  end
+  
   zip_file = "#{PACKAGES_DIR}/#{name}.#{version}.nupkg"
 
   if File.exists? zip_file then

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -99,7 +99,7 @@ def fetch(uri, limit = 10, &block)
     when Net::HTTPRedirection then
       location = response['location']
       puts "redirected to #{location}"
-      if block_given?
+      if block_given? then
         fetch(URI(location), limit - 1, &block)
       else
         fetch(URI(location), limit - 1)
@@ -124,7 +124,7 @@ def ensure_nuget_packages_nix(name, version)
   
   zip_file = "#{PACKAGES_DIR}/#{name}.#{version}.nupkg"
 
-  if File.exists? zip_file then
+  if File.exist? zip_file then
     puts "#{zip_file} already exists, skipping"
     return
   end

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -155,11 +155,11 @@ end
 
 task :binaries => :build do
   Dir.mkdir(BIN_DIR)
-  binaries = FileList["#{OUTPUT_DIR}/*.dll", "#{OUTPUT_DIR}/*.pdb"]
-    .exclude(/nunit/)
-    .exclude(/.Tests/)
-    .exclude(/KayakExamples./)
-
+  binaries = FileList("#{OUTPUT_DIR}/*.dll", "#{OUTPUT_DIR}/*.pdb") do |x|
+    x.exclude(/nunit/)
+    x.exclude(/.Tests/)
+    x.exclude(/KayakExamples./)
+  end
   FileUtils.cp_r binaries, BIN_DIR
 end
 

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -10,6 +10,17 @@ require 'albacore'
 require 'uri'
 require 'net/http'
 require 'net/https'
+# Monkey patch Dir.exists? for Ruby 1.8.x
+if RUBY_VERSION =~ /^1\.8/
+  class Dir
+    class << self
+      def exists? (path)
+        File.directory?(path)
+      end
+      alias_method :exist?, :exists?
+    end
+  end
+end
 
 def is_nix
   !RUBY_PLATFORM.match("linux|darwin").nil?

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -132,7 +132,6 @@ def ensure_nuget_packages_nix(name, version)
     uri = URI.parse("http://packages.nuget.org/api/v1/package/#{name}/#{version}")
 
     fetch(uri) do |seg|
-      puts "got chunk"
       f.write(segment)
     end
 

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -9,6 +9,7 @@ PROJECT_URL = "https://github.com/kayak/kayak"
 require 'albacore'
 require 'uri'
 require 'net/http'
+require 'net/https'
 
 def is_nix
   !RUBY_PLATFORM.match("linux|darwin").nil?
@@ -76,7 +77,11 @@ def fetch(uri, limit = 10)
   # You should choose a better exception.
   raise ArgumentError, 'too many HTTP redirects' if limit == 0
 
-  response = Net::HTTP.get_response(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+  if uri.scheme == "https"
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http.use_ssl = true
+  end
 
   case response
   when Net::HTTPSuccess then

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -94,24 +94,20 @@ def fetch(uri, limit = 10)
     http.use_ssl = true
   end
 
-  resp = http.request(Net::HTTP::Get.new(uri.request_uri)) { |response|
-    case response
-    when Net::HTTPRedirection then
-      location = response['location']
-      puts "redirected to #{location}"
-      response.read_body
-      if block_given?
-        fetch(URI(location), limit - 1, &block)
-      else
-        fetch(URI(location), limit - 1)
-      end
-    else
-      puts "reading from #{uri}"
-      response.read_body do |segment|
-        yield segment
-      end
+  case response
+  when Net::HTTPSuccess then
+    puts "whut"
+    response
+  when Net::HTTPRedirection then
+    location = response['location']
+    puts "redirected to #{location}"
+    fetch(URI(location), limit - 1)
+  else
+    puts "reading from #{location}"
+    response.read_body do |segment|
+      yield segment
     end
-  }
+  end
 end
 
 def ensure_nuget_packages_nix(name, version) 

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -132,7 +132,7 @@ def ensure_nuget_packages_nix(name, version)
     uri = URI.parse("http://packages.nuget.org/api/v1/package/#{name}/#{version}")
 
     fetch(uri) do |seg|
-      f.write(segment)
+      f.write(seg)
     end
 
   ensure


### PR DESCRIPTION
- Redirects now follow and yield properly
- HTTPS support
- Packages folder created if needed
- Support for Ruby 1.8.7 [ships with Mac OS X]
- Chunk download now works
- File saving fixed
- Fix broke FileList exclusion list
