### PR TITLE
Rakefile cleanup and NuGet improvements for MacOS/Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ obj
 .DS_Store
 build
 *.pidb
+TestResult.xml

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -53,9 +53,8 @@ def ensure_submodules()
   system("git submodule update")
 end
 
-# lifted from the docs
 def fetch(uri, limit = 10, &block)
-  # You should choose a better exception.
+  # We should choose a better exception.
   raise ArgumentError, 'too many HTTP redirects' if limit == 0
 
   http = Net::HTTP.new(uri.host, uri.port)
@@ -68,7 +67,6 @@ def fetch(uri, limit = 10, &block)
     case response
     when Net::HTTPRedirection then
       location = response['location']
-      puts "redirected to #{location}"
       if block_given? then
         fetch(URI(location), limit - 1, &block)
       else
@@ -76,7 +74,6 @@ def fetch(uri, limit = 10, &block)
       end
       return
     else
-      puts "reading from #{uri}"
       response.read_body do |segment|
         yield segment
       end

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -226,9 +226,12 @@ end
 
 task :clean do
   FileUtils.rm_rf BUILD_DIR
-  FileUtils.rm_rf PACKAGES_DIR
   FileUtils.rm_rf "Kayak/bin"
   FileUtils.rm_rf "Kayak/obj"
   FileUtils.rm_rf "Kayak.Tests/bin"
   FileUtils.rm_rf "Kayak.Tests/obj"
+end
+
+task :dist_clean => [:clean] do
+  FileUtils.rm_rf PACKAGES_DIR
 end

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -47,37 +47,7 @@ def transform_xml(input, output)
   formatter.write(xml, output_file)
   output_file.close
 end
-
-task :default => [:build, :test]
-  
-CONFIGURATION = "Release"
-BUILD_DIR = File.expand_path("build")
-OUTPUT_DIR = "#{BUILD_DIR}/out"
-BIN_DIR = "#{BUILD_DIR}/bin"
-PACKAGES_DIR = "packages"
-
-assemblyinfo :assemblyinfo => :clean do |a|
-  a.product_name = a.title = PRODUCT
-  a.description = DESCRIPTION
-  a.version = a.file_version = VERSION
-  a.copyright = COPYRIGHT
-  a.output_file = "Kayak/Properties/AssemblyInfo.cs"
-  a.namespaces "System.Runtime.CompilerServices"
-  a.custom_attributes :InternalsVisibleTo => "Kayak.Tests"
-end
-
-msbuild :build_msbuild do |b|
-  b.properties :configuration => CONFIGURATION, "OutputPath" => OUTPUT_DIR
-  b.targets :Build
-  b.solution = "Kayak.sln"
-end
-
-xbuild :build_xbuild do |b|
-  b.properties :configuration => CONFIGURATION, "OutputPath" => OUTPUT_DIR
-  b.targets :Build
-  b.solution = "Kayak.sln"
-end
-
+        
 def ensure_submodules()
   system("git submodule init")
   system("git submodule update")
@@ -163,6 +133,36 @@ def ensure_nuget_packages()
       sh invoke_runtime("tools\\nuget.exe install Kayak.Tests\\packages.config -o #{PACKAGES_DIR}")
       puts "done"
   end
+end
+
+task :default => [:build, :test]
+  
+CONFIGURATION = "Release"
+BUILD_DIR = File.expand_path("build")
+OUTPUT_DIR = "#{BUILD_DIR}/out"
+BIN_DIR = "#{BUILD_DIR}/bin"
+PACKAGES_DIR = "packages"
+
+assemblyinfo :assemblyinfo => :clean do |a|
+  a.product_name = a.title = PRODUCT
+  a.description = DESCRIPTION
+  a.version = a.file_version = VERSION
+  a.copyright = COPYRIGHT
+  a.output_file = "Kayak/Properties/AssemblyInfo.cs"
+  a.namespaces "System.Runtime.CompilerServices"
+  a.custom_attributes :InternalsVisibleTo => "Kayak.Tests"
+end
+
+msbuild :build_msbuild do |b|
+  b.properties :configuration => CONFIGURATION, "OutputPath" => OUTPUT_DIR
+  b.targets :Build
+  b.solution = "Kayak.sln"
+end
+
+xbuild :build_xbuild do |b|
+  b.properties :configuration => CONFIGURATION, "OutputPath" => OUTPUT_DIR
+  b.targets :Build
+  b.solution = "Kayak.sln"
 end
 
 task :build => :assemblyinfo do

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -211,6 +211,7 @@ BUILD_DIR = File.expand_path("build")
 OUTPUT_DIR = "#{BUILD_DIR}/out"
 BIN_DIR = "#{BUILD_DIR}/bin"
 PACKAGES_DIR = "packages"
+PACKAGES = {}
 
 assemblyinfo :assemblyinfo => :clean do |a|
   a.product_name = a.title = PRODUCT

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -135,13 +135,14 @@ def ensure_nuget_package_nix(name)
 end
 
 def all_nuget_packages_present?()
+  result = true
   PACKAGES.values.each { |pkg| 
     if !Dir.exists? pkg[:folder] then
       puts "Package missing: #{pkg[:name]}"
-      return false
+      result = false
     end
   }
-  return true
+  return result
 end
 
 def print_nuget_package_manifest()

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -60,7 +60,7 @@ def fetch(uri, limit = 10, &block)
 
   http = Net::HTTP.new(uri.host, uri.port)
   if uri.scheme == "https"
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.use_ssl = true
   end
   


### PR DESCRIPTION
Commits include support for:
- Split tasks away from utility functions
- NuGet emulation for build time package download [with caching]
- All packages read from packages.config placed anywhere in solution folders
- Tighter SSL checking on package download
- No more specific version references inside Rakefile
- Upgrading NuGet packages should now be transparent cross-platform as long as packages.config is updated
- Updated .gitignore to ignore NUnit test results
- new NuGet support now prints package manifest for improved CI logs
