### PR TITLE
Fixing regular expression not to stop at first paren.

### DIFF
--- a/tools/sake/_update-assemblyinfo.shade
+++ b/tools/sake/_update-assemblyinfo.shade
@@ -11,7 +11,7 @@ update-file each='var updateFile in Files.Include(include)'
     @{
         Action<string, string> replace = (name, value) => {
             if (!string.IsNullOrWhiteSpace(value))
-                updateText = Replace(updateText, name + "\\([^\\)]*\\)", name + "(\"" + value + "\")");
+                updateText = Replace(updateText, name + "\\([^\\)].*\\)", name + "(\"" + value + "\")");
         };
         replace("AssemblyVersion", assemblyVersion);
         replace("AssemblyFileVersion", assemblyFileVersion);


### PR DESCRIPTION
Hey Ben!

Good news, I added some build configs for Kayak on [CodeBetter CI](http://teamcity.codebetter.com/project.html?projectId=project136&tab=projectOverview) for .NET and Mono using Sake for the automated build script.

The configurations are running, but I ran into a small bug with the way _update-assemblyinfo.shade was matching text between parenthesis.  This pull request fixes that bug.  I modified the script not to stop at the first parenthesis found.  Once you pull this in, you should be all set on the CI server.  One thing to note, you need to be careful with false positives until Sake can return exit codes.

Let me know if you have any questions.

Cheers,

Dale
